### PR TITLE
Fix i2C frequency

### DIFF
--- a/imu.ino
+++ b/imu.ino
@@ -51,7 +51,7 @@ unsigned long loop_timer;
 void setup() {
 //  Serial.begin(57600); Only for debug
   Wire.begin();
-  TWBR = 24; // 400kHz I2C clock (200kHz if CPU is 8MHz)
+  TWBR = 12; // Set the I2C clock speed to 400kHz.
 
   setupMpu6050Registers();
   calibrateMpu6050();


### PR DESCRIPTION
As noticed in https://github.com/lobodol/drone-flight-controller/issues/11 the I2C frequency is not set to 400kHz but to 250kHz.
Fix this.